### PR TITLE
Implement metadata token resolution

### DIFF
--- a/DecompilerServer.csproj
+++ b/DecompilerServer.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
     <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.4" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="9.1.0.7988" />
+    <PackageReference Include="System.Reflection.Metadata" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Services/MemberResolver.cs
+++ b/Services/MemberResolver.cs
@@ -1,5 +1,6 @@
 using ICSharpCode.Decompiler.TypeSystem;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Text.RegularExpressions;
 using System.Collections.Concurrent;
 
@@ -198,12 +199,16 @@ public class MemberResolver
 
     private IEntity? ResolveMemberByToken(int token, ICompilation compilation)
     {
-        // For now, simplified token resolution - full implementation would use PEFile metadata reader
         try
         {
-            // This is a simplified approach - in practice you'd need to properly parse metadata tokens
-            // using the PEFile and map them to IEntity objects through the TypeSystem
-            return null; // TODO: Implement proper token resolution
+            var peFile = _contextManager.GetPEFile();
+            _ = peFile.Metadata; // ensure metadata is loaded
+
+            if (compilation.MainModule is not ICSharpCode.Decompiler.TypeSystem.MetadataModule module)
+                return null;
+
+            var handle = MetadataTokens.EntityHandle(token);
+            return module.ResolveEntity(handle);
         }
         catch
         {

--- a/Tests/UnitTest1.cs
+++ b/Tests/UnitTest1.cs
@@ -1,4 +1,6 @@
 using DecompilerServer.Services;
+using ICSharpCode.Decompiler.TypeSystem;
+using System.Reflection.Metadata.Ecma335;
 
 namespace Tests;
 
@@ -31,6 +33,30 @@ public class SimpleServiceTests : ServiceTestBase
         Assert.True(MemberResolver.IsValidMemberId("T:TestLibrary.SimpleClass"));
         Assert.False(MemberResolver.IsValidMemberId(""));
         Assert.False(MemberResolver.IsValidMemberId("InvalidFormat"));
+    }
+
+    [Fact]
+    public void MemberResolver_ResolveHexToken_ShouldReturnMember()
+    {
+        var method = (IMethod)MemberResolver.ResolveMember("M:TestLibrary.SimpleClass.SimpleMethod")!;
+        var token = $"0x{MetadataTokens.GetToken(method.MetadataToken):X8}";
+
+        var resolved = MemberResolver.ResolveMember(token);
+
+        Assert.NotNull(resolved);
+        Assert.Equal(method, resolved);
+    }
+
+    [Fact]
+    public void MemberResolver_ResolveDecimalToken_ShouldReturnMember()
+    {
+        var field = (IField)MemberResolver.ResolveMember("F:TestLibrary.SimpleClass.PublicField")!;
+        var token = MetadataTokens.GetToken(field.MetadataToken).ToString();
+
+        var resolved = MemberResolver.ResolveMember(token);
+
+        Assert.NotNull(resolved);
+        Assert.Equal(field, resolved);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- resolve metadata tokens by reading PE metadata and mapping to IEntity
- cover MemberResolver token resolution with hexadecimal and decimal tests

## Testing
- `dotnet format DecompilerServer.sln --verbosity minimal`
- `dotnet build DecompilerServer.sln`
- `dotnet test DecompilerServer.sln` *(fails: Tests.ToolImplementationTests.PlanChunking_WithValidMember_ReturnsChunkPlan)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf989ceb48329a35fbb8ce2553a98