### PR TITLE
Implement IL parsing for usage analysis

### DIFF
--- a/Tests/ServiceIntegrationTests.cs
+++ b/Tests/ServiceIntegrationTests.cs
@@ -169,6 +169,22 @@ public class ServiceIntegrationTests : ServiceTestBase
         Assert.True(hasSimpleClass, "Should find SimpleClass in search results");
     }
 
+    [Fact]
+    public void UsageAnalyzer_FindCallees_ShouldDetectBaseMethodCall()
+    {
+        var analyzer = new UsageAnalyzer(ContextManager, MemberResolver);
+        var callees = analyzer.FindCallees("M:TestLibrary.DerivedClass.VirtualMethod").ToList();
+        Assert.Contains(callees, c => c.InMember == "M:TestLibrary.BaseClass.VirtualMethod");
+    }
+
+    [Fact]
+    public void UsageAnalyzer_FindStringLiterals_ShouldFindLiteral()
+    {
+        var analyzer = new UsageAnalyzer(ContextManager, MemberResolver);
+        var literals = analyzer.FindStringLiterals("Simple method called").ToList();
+        Assert.Contains(literals, l => l.Value == "Simple method called");
+    }
+
     private class TestSearchService : SearchServiceBase
     {
         public TestSearchService(AssemblyContextManager contextManager, MemberResolver memberResolver)


### PR DESCRIPTION
## Summary
- parse method bodies with IL opcodes to detect callees, usages, and string literals
- add integration tests for call graph and string literal lookup

## Testing
- `dotnet format DecompilerServer.sln`
- `dotnet build DecompilerServer.sln`
- `dotnet test DecompilerServer.sln` *(fails: PlanChunking_WithValidMember_ReturnsChunkPlan)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf9eb84548329b1fb7c29d52a088a