### PR TITLE
Add overlap validation and boundary tests for PlanChunking

### DIFF
--- a/Tests/ToolImplementationTests.cs
+++ b/Tests/ToolImplementationTests.cs
@@ -1421,6 +1421,46 @@ public class ToolImplementationTests : ServiceTestBase
     }
 
     [Fact]
+    public void PlanChunking_WithNegativeOverlap_ReturnsError()
+    {
+        // Arrange - find a method from the test assembly
+        var types = ContextManager.GetAllTypes();
+        var testType = types.FirstOrDefault(t => t.Methods.Any(m => !m.IsConstructor));
+        Assert.NotNull(testType);
+
+        var method = testType.Methods.First(m => !m.IsConstructor);
+        var memberId = MemberResolver.GenerateMemberId(method);
+
+        // Act
+        var result = PlanChunkingTool.PlanChunking(memberId, targetChunkSize: 1000, overlap: -1);
+
+        // Assert
+        Assert.NotNull(result);
+        var response = JsonSerializer.Deserialize<JsonElement>(result);
+        Assert.Equal("error", response.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public void PlanChunking_WithOverlapEqualChunkSize_ReturnsError()
+    {
+        // Arrange - find a method from the test assembly
+        var types = ContextManager.GetAllTypes();
+        var testType = types.FirstOrDefault(t => t.Methods.Any(m => !m.IsConstructor));
+        Assert.NotNull(testType);
+
+        var method = testType.Methods.First(m => !m.IsConstructor);
+        var memberId = MemberResolver.GenerateMemberId(method);
+
+        // Act - use very small chunk size to ensure target lines per chunk is 1
+        var result = PlanChunkingTool.PlanChunking(memberId, targetChunkSize: 1, overlap: 1);
+
+        // Assert
+        Assert.NotNull(result);
+        var response = JsonSerializer.Deserialize<JsonElement>(result);
+        Assert.Equal("error", response.GetProperty("status").GetString());
+    }
+
+    [Fact]
     public void GetAstOutline_WithValidMember_ReturnsOutline()
     {
         // Arrange - find a method from the test assembly

--- a/Tools/PlanChunking.cs
+++ b/Tools/PlanChunking.cs
@@ -69,6 +69,13 @@ public static class PlanChunkingTool
                 // Calculate target lines per chunk
                 var targetLinesPerChunk = Math.Max(1, targetChunkSize / avgCharsPerLine);
 
+                if (overlap >= targetLinesPerChunk || overlap < 0)
+                {
+                    throw new ArgumentException(
+                        $"Overlap must be between 0 and {targetLinesPerChunk - 1}",
+                        nameof(overlap));
+                }
+
                 var chunks = new List<object>();
                 var currentStart = 1;
 


### PR DESCRIPTION
## Summary
- guard PlanChunking against invalid overlap values
- test PlanChunking with negative and boundary overlaps

## Testing
- `dotnet format DecompilerServer.sln`
- `dotnet build DecompilerServer.sln`
- `dotnet test DecompilerServer.sln`


------
https://chatgpt.com/codex/tasks/task_e_68bdffb8e4688329b910a36ab4646ea0